### PR TITLE
Update `multi.KeyValueStringFlag` to implement `Set` and `String` methods.

### DIFF
--- a/multi/keyvalue.go
+++ b/multi/keyvalue.go
@@ -41,6 +41,10 @@ func (e *KeyValueStringFlag) Value() interface{} {
 	return e.value
 }
 
+func (e *KeyValueStringFlag) String() string {
+	return fmt.Sprintf("%s=%s", e.key, e.value)
+}
+
 type KeyValueCSVString []*KeyValueStringFlag
 
 func (e *KeyValueCSVString) String() string {

--- a/multi/keyvalue.go
+++ b/multi/keyvalue.go
@@ -23,6 +23,20 @@ func (e *KeyValueStringFlag) Key() string {
 	return e.key
 }
 
+func (e *KeyValueStringFlag) Set(value string) error {
+
+	value = strings.Trim(value, " ")
+	kv := strings.Split(value, SEP)
+
+	if len(kv) != 2 {
+		return errors.New("Invalid key=value argument")
+	}
+
+	e.key = kv[0]
+	e.value = kv[1]
+	return nil
+}
+
 func (e *KeyValueStringFlag) Value() interface{} {
 	return e.value
 }
@@ -45,18 +59,15 @@ func (e *KeyValueCSVString) Set(value string) error {
 	for _, v := range strings.Split(value, ",") {
 
 		value = strings.Trim(v, " ")
-		kv := strings.Split(v, SEP)
 
-		if len(kv) != 2 {
-			return errors.New("Invalid key=value argument")
+		a := new(KeyValueStringFlag)
+		err := a.Set(value)
+
+		if err != nil {
+			return err
 		}
 
-		a := KeyValueStringFlag{
-			key:   kv[0],
-			value: kv[1],
-		}
-
-		*e = append(*e, &a)
+		*e = append(*e, a)
 	}
 
 	return nil
@@ -70,19 +81,14 @@ func (e *KeyValueString) String() string {
 
 func (e *KeyValueString) Set(value string) error {
 
-	value = strings.Trim(value, " ")
-	kv := strings.Split(value, SEP)
+	a := new(KeyValueStringFlag)
+	err := a.Set(value)
 
-	if len(kv) != 2 {
-		return errors.New("Invalid key=value argument")
+	if err != nil {
+		return err
 	}
 
-	a := KeyValueStringFlag{
-		key:   kv[0],
-		value: kv[1],
-	}
-
-	*e = append(*e, &a)
+	*e = append(*e, a)
 	return nil
 }
 

--- a/multi/keyvalue_test.go
+++ b/multi/keyvalue_test.go
@@ -6,7 +6,39 @@ import (
 )
 
 func TestMultiKeyValuet(t *testing.T) {
-	t.Skip()
+
+	kv := new(KeyValueStringFlag)
+	err := kv.Set("foo=bar")
+
+	if err != nil {
+		t.Fatalf("Failed to set KeyValueStringFlag, %v", err)
+	}
+
+	v := kv.Value().(string)
+
+	if v != "bar" {
+		t.Fatalf("Invalid value for KeyValueStringFlag")
+	}
+
+	multi_kv := new(KeyValueString)
+	err = multi_kv.Set("bar=foo")
+
+	if err != nil {
+		t.Fatalf("Failed to set multi KeyValueString, %v", err)
+	}
+
+	v2 := multi_kv.Get().(KeyValueString)
+
+	if len(v2) != 1 {
+		t.Fatal("Invalid count for multi KeyValueString")
+	}
+
+	multi_v := v2[0].Value().(string)
+
+	if multi_v != "foo" {
+		t.Fatalf("Invalid value for multi KeyValueString")
+	}
+
 }
 
 func TestKeyValueCSVString(t *testing.T) {


### PR DESCRIPTION
* Update `multi.KeyValueStringFlag` to implement `Set` and `String` methods.
* Update `multi.KeyValueString` and `multi.KeyValueCSVString` instances to use `multi.KeyValueStringFlag.Set` method